### PR TITLE
Files with read only attribute set were not deleted from temp repo folder

### DIFF
--- a/Solutions/Endjin.Templify.Domain/Domain/Packager/Processors/CleanUpProcessor.cs
+++ b/Solutions/Endjin.Templify.Domain/Domain/Packager/Processors/CleanUpProcessor.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Endjin.Templify.Domain.Domain.Packager.Processors
 {
     #region Using Directives
@@ -28,10 +30,34 @@ namespace Endjin.Templify.Domain.Domain.Packager.Processors
             
             if (Directory.Exists(path))
             {
-                Directory.Delete(path, true);
+                ForceDeleteDirectory(path);
             }
             
             this.progressNotifier.UpdateProgress(ProgressStage.CreatingArchive, 2, 2);
+        }
+
+        private static void ForceDeleteDirectory(string path)
+        {
+            DirectoryInfo currentFolder;
+            Stack<DirectoryInfo> folders = new Stack<DirectoryInfo>();
+            DirectoryInfo root = new DirectoryInfo(path);
+            folders.Push(root);
+            while (folders.Count > 0)
+            {
+                currentFolder = folders.Pop();
+                currentFolder.Attributes = currentFolder.Attributes & ~(FileAttributes.Archive | FileAttributes.ReadOnly | FileAttributes.Hidden);
+                foreach (DirectoryInfo d in currentFolder.GetDirectories())
+                {
+                    folders.Push(d);
+                }
+                foreach (FileInfo fileInFolder in currentFolder.GetFiles())
+                {
+                    fileInFolder.Attributes = fileInFolder.Attributes & ~(FileAttributes.Archive | FileAttributes.ReadOnly | FileAttributes.Hidden);
+                    fileInFolder.Delete();
+                }
+            }
+
+            root.Delete(true);
         }
     }
 }


### PR DESCRIPTION
Added force delete method in order to remove all files in cleanup processor. 

Previously exception was thrown and logged:

Access to the path 'AjaxControlToolkit.dll' is denied.
   at System.IO.Directory.DeleteHelper(String fullPath, String userPath, Boolean recursive)
   at System.IO.Directory.Delete(String fullPath, String userPath, Boolean recursive)
   at Endjin.Templify.Domain.Domain.Packager.Processors.CleanUpProcessor.Process(String path) in C:_Projects\endjin\OSS\Templify\Solutions\Endjin.Templify.Domain\Domain\Packager\Processors\CleanUpProcessor.cs:line 31
   at Endjin.Templify.Domain.Tasks.PackageCreatorTasks.RunCreatePackage() in C:_Projects\endjin\OSS\Templify\Solutions\Endjin.Templify.Domain\Tasks\PackageCreatorTasks.cs:line 93
   at Endjin.Templify.Domain.Tasks.PackageCreatorTasks.CreatePackage(CommandOptions options) in C:_Projects\endjin\OSS\Templify\Solutions\Endjin.Templify.Domain\Tasks\PackageCreatorTasks.cs:line 74
   at Endjin.Templify.Client.ViewModel.CreatePackageViewModel.ExecuteCreatePackage() in C:_Projects\endjin\OSS\Templify\Solutions\Endjin.Templify.Client\ViewModel\CreatePackageViewModel.cs:line 74
   at Endjin.Templify.Domain.Framework.Threading.BackgroundWorkerManager.<>c__DisplayClass3.<RunBackgroundWork>b__0(Object , DoWorkEventArgs ) in C:_Projects\endjin\OSS\Templify\Solutions\Endjin.Templify.Domain\Framework\Threading\BackgroundWorkerManager.cs:line 15
   at System.ComponentModel.BackgroundWorker.OnDoWork(DoWorkEventArgs e)
   at System.ComponentModel.BackgroundWorker.WorkerThreadStart(Object argument)
